### PR TITLE
Fixed bug returning `nil` for `.fetchRequest()`

### DIFF
--- a/templates/machine.swift.motemplate
+++ b/templates/machine.swift.motemplate
@@ -48,7 +48,7 @@ open class _<$sanitizedManagedObjectClassName$>: NSManagedObject {
     @nonobjc
     open class func fetchRequest() -> NSFetchRequest<<$sanitizedManagedObjectClassName$>> {
         if #available(iOS 10.0, tvOS 10.0, watchOS 3.0, macOS 10.12, *) {
-            return NSManagedObject.fetchRequest() as! NSFetchRequest<<$sanitizedManagedObjectClassName$>>
+            return self.fetchRequest() as! NSFetchRequest<<$sanitizedManagedObjectClassName$>>
         } else {
             return NSFetchRequest(entityName: self.entityName())
         }


### PR DESCRIPTION
Calling `NSManagedObject.fetchRequest()` is invalid:

> This method is only legal to call on **subclasses of `NSManagedObject`** that represent a single entity in the model.

https://developer.apple.com/documentation/coredata/nsmanagedobject/1640605-fetchrequest

The proper way is to call `self.fetchRequest()` on a subclass of `NSManagedObject`.